### PR TITLE
Trigram correction

### DIFF
--- a/nlp-code.py
+++ b/nlp-code.py
@@ -1,113 +1,130 @@
-## Char trigrams generation file
+# Char trigrams generation file
 
 import os
 import sys
+import heapq  # We use heap queue as a dictionary sorting structure.
+from pathlib import Path
 
 
-## Resources
+# Resources
 
 # Language
-class lang(object):
+class Language(object):
     def __init__(self, native, family, language_name):
         self.native = native
         self.family = family
         self.language_name = language_name
 
+
 # Trigram Count
-class tri_count(object):
+class TriCount(object):
     def __init__(self, tri, count):
         self.tri = tri
         self.count = count
 
-## list of languages creation
-#languagues families:   Germanic, BaltoSlavic, Romance, NativeEnglish ,Albanian, Armenian, NonEuropean,
-#                       Finno-Permic, AfroAsiatic, Turkic, Hellenic, Finnic, Karto-Zan
-languages_dict = {
-            'Albania': lang(False, 'Albanian', 'Albania'),
-            'Armenia': lang(False, 'Armenian', 'Armenia'),
-            'Australia': lang(True, 'NativeEnglish', 'English'),
-            'Austria': lang(False, 'Germanic', 'German'),
-            'Bosnia': lang(False, 'BaltoSlavic', 'Bosnia'),
-            'Bulgaria': lang(False, 'BaltoSlavic', 'Bulgaria'),
-            'Canada': lang(True, 'NativeEnglish', 'English'),
-            'China': lang(False, 'NonEuropean', 'China'),
-            'Croatia': lang(False, 'BaltoSlavic', 'Croatia'),
-            'Cyprus': lang(False, 'Hellenic', 'Greece'),
-            'Czech': lang(False, 'BaltoSlavic', 'Czech'),
-            'Denmark': lang(False, 'Germanic', 'Denmark'),
-            'Estonia': lang(False, 'Finnic', 'Estonia'),
-            'Finland': lang(False, 'Finnic', 'Finland'),
-            'Frace': lang(False, 'Romance', 'France'),
-            'Georgia': lang(False, 'Karto-Zan', 'Georgia'),
-            'Germany': lang(False, 'Germanic', 'German'),
-            'Greece': lang(False, 'Hellenic', 'Greece'),
-            'Hungary': lang(False, 'Finno-Permic', 'Hungary'),
-            'Iceland': lang(False, 'Germanic', 'Iceland'),
-            'Ireland': lang(True, 'NativeEnglish', 'English' ),
-            'Israel': lang(False, 'AfroAsiatic', 'Israel'),
-            'Italy': lang(False, 'Romance','Italy'),
-            'Latvia': lang(False, 'BaltoSlavic', 'Latvia'),
-            'Lithuania': lang(False, 'BaltoSlavic', 'Lithuania'),
-            'Macedonia': lang(False, 'BaltoSlavic', 'Macedonia'),
-            'Malta': lang(False, 'AfroAsiatic', 'Malta'),
-            'Mexico': lang(False, 'Romance', 'Spanish'),
-            'Moldova': lang(False, 'Romance', 'Romania'),
-            'Montenegro': lang(False, 'BaltoSlavic', 'Montenegro'),
-            'Netherlands': lang(False, 'Germanic', 'Netherlands'),
-            'NewZealand': lang(True, 'NativeEnglish', 'English'),
-            'Norway': lang(False, 'Germanic', 'Norway'),
-            'Poland': lang(False, 'BaltoSlavic', 'Poland'),
-            'Portugal': lang(False, 'Romance', 'Portugal'),
-            'Romania': lang(False, 'Romance', 'Romania'),
-            'Russia': lang(False, 'BaltoSlavic', 'Russia'),
-            'Serbia': lang(False, 'BaltoSlavic', 'Serbia'),
-            'Slovakia': lang(False, 'BaltoSlavic', 'Slovakia'),
-            'Slovenia': lang(False, 'BaltoSlavic', 'Slovenia'),
-            'Spain': lang(False, 'Romance', 'Spanish'),
-            'Sweden': lang(False, 'Germanic', 'Sweden'),
-            'Turkey': lang(False, 'Turkic', 'Turkey'),
-            'UK': lang(True, 'NativeEnglish', 'English'),
-            'Ukraine': lang(False, 'BaltoSlavic', 'Ukraine'),
-            'US': lang(True, 'Turkic', 'English'),
-            'Vietnam': lang(False, 'NonEuropean', 'Vietnam')
+
+"""
+Language families:     Germanic, BaltoSlavic, Romance, NativeEnglish ,Albanian, Armenian, NonEuropean,
+                       Finno-Permic, AfroAsiatic, Turkic, Hellenic, Finnic, Karto-Zan
+"""
+
+Language_dict = {
+            'Albania': Language(False, 'Albanian', 'Albania'),
+            'Armenia': Language(False, 'Armenian', 'Armenia'),
+            'Australia': Language(True, 'NativeEnglish', 'English'),
+            'Austria': Language(False, 'Germanic', 'German'),
+            'Bosnia': Language(False, 'BaltoSlavic', 'Bosnia'),
+            'Bulgaria': Language(False, 'BaltoSlavic', 'Bulgaria'),
+            'Canada': Language(True, 'NativeEnglish', 'English'),
+            'China': Language(False, 'NonEuropean', 'China'),
+            'Croatia': Language(False, 'BaltoSlavic', 'Croatia'),
+            'Cyprus': Language(False, 'Hellenic', 'Greece'),
+            'Czech': Language(False, 'BaltoSlavic', 'Czech'),
+            'Denmark': Language(False, 'Germanic', 'Denmark'),
+            'Estonia': Language(False, 'Finnic', 'Estonia'),
+            'Finland': Language(False, 'Finnic', 'Finland'),
+            'Frace': Language(False, 'Romance', 'France'),
+            'Georgia': Language(False, 'Karto-Zan', 'Georgia'),
+            'Germany': Language(False, 'Germanic', 'German'),
+            'Greece': Language(False, 'Hellenic', 'Greece'),
+            'Hungary': Language(False, 'Finno-Permic', 'Hungary'),
+            'Iceland': Language(False, 'Germanic', 'Iceland'),
+            'Ireland': Language(True, 'NativeEnglish', 'English' ),
+            'Israel': Language(False, 'AfroAsiatic', 'Israel'),
+            'Italy': Language(False, 'Romance','Italy'),
+            'Latvia': Language(False, 'BaltoSlavic', 'Latvia'),
+            'Lithuania': Language(False, 'BaltoSlavic', 'Lithuania'),
+            'Macedonia': Language(False, 'BaltoSlavic', 'Macedonia'),
+            'Malta': Language(False, 'AfroAsiatic', 'Malta'),
+            'Mexico': Language(False, 'Romance', 'Spanish'),
+            'Moldova': Language(False, 'Romance', 'Romania'),
+            'Montenegro': Language(False, 'BaltoSlavic', 'Montenegro'),
+            'Netherlands': Language(False, 'Germanic', 'Netherlands'),
+            'NewZealand': Language(True, 'NativeEnglish', 'English'),
+            'Norway': Language(False, 'Germanic', 'Norway'),
+            'Poland': Language(False, 'BaltoSlavic', 'Poland'),
+            'Portugal': Language(False, 'Romance', 'Portugal'),
+            'Romania': Language(False, 'Romance', 'Romania'),
+            'Russia': Language(False, 'BaltoSlavic', 'Russia'),
+            'Serbia': Language(False, 'BaltoSlavic', 'Serbia'),
+            'Slovakia': Language(False, 'BaltoSlavic', 'Slovakia'),
+            'Slovenia': Language(False, 'BaltoSlavic', 'Slovenia'),
+            'Spain': Language(False, 'Romance', 'Spanish'),
+            'Sweden': Language(False, 'Germanic', 'Sweden'),
+            'Turkey': Language(False, 'Turkic', 'Turkey'),
+            'UK': Language(True, 'NativeEnglish', 'English'),
+            'Ukraine': Language(False, 'BaltoSlavic', 'Ukraine'),
+            'US': Language(True, 'Turkic', 'English'),
+            'Vietnam': Language(False, 'NonEuropean', 'Vietnam')
 }
 
-## Generate dictionary from files
+# Generate dictionary from files
 
 base_path = os.path.dirname(os.path.realpath(__file__));
-main_dir = os.path.join(base_path, sys.argv[1])  # Files directory
+main_dir = sys.argv[1]  # Files directory
+i = 0
 
-for sub_dir in main_dir:
-    if os.path.dirname(sub_dir) == "europe_data":  # europe_data directory
+for sub_dir in os.scandir(main_dir):
+    print(sub_dir)
+    if sub_dir.name == "europe_data":  # europe_data directory
         in_domain_dict = {}
-        for country_dir in sub_dir:
-            for user_dir in country_dir:
-                for file_dir in user_dir:
+
+        """ 
+        Parse all files and set in_domain_dict to contain all trigram chars
+        We expect to have all trigrams in a {trigram_chars, count} format
+        """
+        for country_dir in os.scandir(sub_dir):  # parse country directories (exm: reddit.Albania.txt.tok.clean)
+            for user_dir in os.scandir(country_dir):  # parse user directories (exm: user_name)
+                for file_dir in os.scandir(user_dir):  # parse chunk files (exm: char_ngram_chunk1)
                     trigram_count = 0
-                    file = open(file_dir, "r")
+                    file = open(file_dir, "r", encoding="utf-8")
                     lines = file.readlines()
-                    for line in lines:
-                        p = 0
-                        while p < len(line):
-                            trigram = line[p + 1] + line[p + 4] + line[p + 7]
-                            if trigram not in in_domain_dict.keys():
-                                in_domain_dict[trigram] = 1
-                                trigram_count += 1
-                            else:
-                                in_domain_dict[trigram] += 1
-                            p += 11
+                    for line in lines:  # parse lines within chunk text
+                        if len(line) >= 11:
+                            cur_char = 0
+                            while cur_char < len(line):
+                                # print (country_dir,":",user_dir,":",file_dir)
+                                trigram = line[cur_char + 1] + line[cur_char + 4] + line[cur_char + 7]
+                                if trigram not in in_domain_dict.keys():
+                                    in_domain_dict[trigram] = 1
+                                    trigram_count += 1
+                                else:
+                                    in_domain_dict[trigram] += 1
+                                cur_char += 11
+                # DEBUG: print("[", i, "]", " processing user ", user_dir)
+                i += 1
+            # DEBUG: print("processing country ", country_dir)
 
-        tri_count_arr = list()
-        for tri, count in in_domain_dict.items():
-            tri_count_arr.append(tri_count(tri, count))
+        # Fetch top 1000 tri-chars
+        top_trigrams = heapq.nlargest(1000, in_domain_dict)  # OPTIMIZE: Faster sort?
 
-        # Sort tri_count_arr
-
-        # Picking top 1000 tri-chars
+        # TEST: Fetched trigrams
+        for top_trigram in top_trigrams: # DEBUG: Doesn't print non-english letters. does it even tell?
+            print(top_trigram)
 
         # Making user feature vectors
 
-        # classification
+        # Classification
 
     elif os.path.dirname(sub_dir) == "non_europe_data":
         pass


### PR DESCRIPTION
- Fixed file iteration using os.scandir()

- The parser now correctly parse files using utf-8 encoding for non-English characters.

- Changed lang structure to Language - Better readability according to the python convention

- Changed tri_count structure to TriCount - Better readability according to the python convention

- Added heapq support for dict sorting using the nlargest() method

- New convention: use the keywords TODO, FIXME, OPTIMIZE, DEBUG, TEST in comments to allow color support for better readability in PyCharm